### PR TITLE
model_publishhistory: fix bug in versions(#9145)

### DIFF
--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -79,10 +79,8 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
         # when we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items
         # which have the same project, same entity assocation, same name, same type 
-        # and the same task.
         filters = [ ["project", "is", sg_data["project"] ],
                     ["name", "is", sg_data["name"] ],
-                    ["task", "is", sg_data["task"] ],
                     ["entity", "is", sg_data["entity"] ],
                     [publish_type_field, "is", sg_data[publish_type_field] ],
                   ]


### PR DESCRIPTION
The loader was only loading the versions with the same task as the latest, so some were being left out
