### PR TITLE
Add more fields to query (RDEV-13628)

### DIFF
--- a/python/tk_multi_loader/constants.py
+++ b/python/tk_multi_loader/constants.py
@@ -25,10 +25,17 @@ PUBLISHED_FILES_FIELDS = ["name",
                           "task.Task.sg_status_list",
                           "task.Task.due_date",
                           "project",
+                          "project.Project.code",
                           "task.Task.content",
                           "created_by",
                           "created_at",
-                          "version", # note: not supported on TankPublishedFile so always None
+                          "version",  # note: not supported on TankPublishedFile so always None
                           "version.Version.sg_status_list",
-                          "created_by.HumanUser.image"
+                          "created_by.HumanUser.image",
+                          "sg_path",
+                          "sg_metadata",
+                          "tags",
+                          "sg_variant",
+                          "sg_step",
+                          "sg_lod",
                           ]

--- a/python/tk_multi_loader/loader_action_manager.py
+++ b/python/tk_multi_loader/loader_action_manager.py
@@ -145,8 +145,11 @@ class LoaderActionManager(ActionManager):
         # Dictionary of all actions that are common to all publishes in the selection.
         # The key is the action name, the value is the a list of data pairs. Each data pair
         # holds the Shotgun Item the action is for and the action description.
-        intersection_actions_per_name = dict(
-            [(action["name"], [(sg_data_list[0], action)]) for action in first_entity_actions]
+        #
+        # Rodeo note: We can have multiple actions for the same TankPublishedFile
+        # but with different params. However we don't expect to have multiple actions with the same caption.
+        intersection_actions_per_caption = dict(
+            [(action["caption"], [(sg_data_list[0], action)]) for action in first_entity_actions]
         )
 
         # ... and then we'll remove actions from that set as we encounter entities without those actions.
@@ -162,23 +165,23 @@ class LoaderActionManager(ActionManager):
             # Turn the list of actions into a dictionary of actions using the key
             # as the name.
             publish_actions = dict(
-                [(action["name"], action) for action in publish_actions]
+                [(action["caption"], action) for action in publish_actions]
             )
 
             # Check if the actions from the intersection are available for this publish
             #
             # Get a copy of the keys because we're about to remove items as they are visited.
-            for name in intersection_actions_per_name.keys():
+            for caption in intersection_actions_per_caption.keys():
                 # If the action is available for that publish, add the publish's action to the intersection
-                publish_action = publish_actions.get(name)
+                publish_action = publish_actions.get(caption)
                 if publish_action:
-                    intersection_actions_per_name[name].append((sg_data, publish_action))
+                    intersection_actions_per_caption[caption].append((sg_data, publish_action))
                 else:
                     # Otherwise remove this action from the intersection
-                    del intersection_actions_per_name[name]
+                    del intersection_actions_per_caption[caption]
 
             # Early out, happens if the intersection has been made empty.
-            if not intersection_actions_per_name:
+            if not intersection_actions_per_caption:
                 break
 
         # We need to order the resulting intersection like the actions were returned
@@ -190,9 +193,9 @@ class LoaderActionManager(ActionManager):
         for action in first_entity_actions:
             # If that action is still present in the intersection, add it to the final
             # list of actions
-            if action["name"] in intersection_actions_per_name:
+            if action["caption"] in intersection_actions_per_caption:
                 intersection_actions.append(
-                    intersection_actions_per_name[action["name"]]
+                    intersection_actions_per_caption[action["caption"]]
                 )
 
         # For every actions in the intersection, create an associated QAction with appropriate callback


### PR DESCRIPTION
**Purpose of the PR / What does this do?**
This PR add values in the queried fields so newly implemented hooks can have access to them.
It also fix an issue when a TankPublishedFile have multiple actions sharing the same name.
Internal logic in tk-multi-loader2 group actions by their name which make them clashes between each others.

**Overview of the changes (don't assume any history)**
Added some fields.
I also modified the logic to that actions are grouped by caption instead of name.

**Type of feedback wanted**
Any feedback is welcome, this should be straightforward.

**Where should the reviewer start looking at?**
See rdo_tk_config PR # 44

**Potential risks of this change, if any.**
None

**Relationship with other PRs**
See rdo_tk_config PR # 44